### PR TITLE
test: make TLS fingerprint regression deterministic

### DIFF
--- a/app/src/test/java/io/github/mouse233/localsendkotlin/security/TlsIdentityTest.kt
+++ b/app/src/test/java/io/github/mouse233/localsendkotlin/security/TlsIdentityTest.kt
@@ -15,12 +15,15 @@ import java.security.KeyStore
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.Date
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLServerSocket
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.TrustManager
+import javax.net.ssl.X509KeyManager
 import javax.net.ssl.X509TrustManager
 
 class TlsIdentityTest {
@@ -52,14 +55,20 @@ class TlsIdentityTest {
         try {
             val expected = TlsIdentity.certificateFingerprint(client.second)
             val actual = AtomicReference<String?>()
+            val failure = AtomicReference<Throwable?>()
+            val clientByteRead = CountDownLatch(1)
             val acceptor = Thread {
                 val socket = serverSocket.accept() as SSLSocket
                 try {
                     socket.getInputStream().read() // NanoHTTPD touches the stream first
+                    clientByteRead.countDown()
                     socket.startHandshake()        // the fix: explicit, idempotent handshake
                     val peer = socket.session.peerCertificates.firstOrNull()
                         ?: throw IllegalStateException("Peer did not present a certificate")
                     actual.set(TlsIdentity.certificateFingerprint(peer))
+                } catch (exception: Throwable) {
+                    failure.set(exception)
+                    clientByteRead.countDown()
                 } finally {
                     socket.close()
                 }
@@ -68,10 +77,12 @@ class TlsIdentityTest {
 
             val clientSocket = clientSocket(serverSocket.localPort, client.first, password)
             clientSocket.startHandshake()
-            clientSocket.getOutputStream().write(0)
+            clientSocket.getOutputStream().apply { write(0); flush() }
+            check(clientByteRead.await(10, TimeUnit.SECONDS)) { "Server did not consume the request byte" }
             clientSocket.close()
             acceptor.join(10_000)
 
+            failure.get()?.let { throw AssertionError("Server TLS flow failed", it) }
             assertNotNull("Server failed to capture the peer fingerprint", actual.get())
             assertEquals(expected, actual.get())
         } finally {
@@ -111,9 +122,38 @@ class TlsIdentityTest {
         val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
         kmf.init(store, password)
         val context = SSLContext.getInstance("TLS")
-        context.init(kmf.keyManagers, arrayOf<TrustManager>(acceptAll()), SecureRandom())
+        context.init(forceClientAlias(kmf.keyManagers), arrayOf<TrustManager>(acceptAll()), SecureRandom())
         return context.socketFactory.createSocket("127.0.0.1", port) as SSLSocket
     }
+
+    /** Self-signed client certificates have no issuer match to guide the default key manager. */
+    private fun forceClientAlias(keyManagers: Array<javax.net.ssl.KeyManager>): Array<javax.net.ssl.KeyManager> =
+        keyManagers.map { manager ->
+            if (manager !is X509KeyManager) return@map manager
+            object : X509KeyManager {
+                override fun chooseClientAlias(
+                    keyType: Array<String>,
+                    issuers: Array<java.security.Principal>?,
+                    socket: java.net.Socket?
+                ): String = "id"
+
+                override fun chooseServerAlias(
+                    keyType: String,
+                    issuers: Array<java.security.Principal>?,
+                    socket: java.net.Socket?
+                ): String = manager.chooseServerAlias(keyType, issuers, socket)
+
+                override fun getClientAliases(keyType: String, issuers: Array<java.security.Principal>?): Array<String> =
+                    manager.getClientAliases(keyType, issuers)
+
+                override fun getServerAliases(keyType: String, issuers: Array<java.security.Principal>?): Array<String> =
+                    manager.getServerAliases(keyType, issuers)
+
+                override fun getCertificateChain(alias: String?): Array<X509Certificate>? = manager.getCertificateChain(alias)
+
+                override fun getPrivateKey(alias: String?): java.security.PrivateKey? = manager.getPrivateKey(alias)
+            }
+        }.toTypedArray()
 
     private fun acceptAll(): X509TrustManager = object : X509TrustManager {
         override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit


### PR DESCRIPTION
修复 PR #1 附带的 TLS 回归测试：\n\n- 强制测试客户端选择自签名客户端证书\n- 将服务端线程中的握手异常传回测试线程\n- 保留 LocalSendServer 的 Android 5.1 生产修复不变\n\n本地使用 Android Studio JBR 17 执行 :app:testDebugUnitTest 已通过。