### PR TITLE
chore: prepare v0.1.1-alpha release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.1.1-alpha] - 2026-08-22
+
+### Fixed
+
+- Fixed file receiving on Android 5.1 by capturing the peer TLS certificate fingerprint after the TLS handshake completes.
+- Added a deterministic TLS fingerprint regression test for the NanoHTTPD/SSL handshake flow.
+
+## 中文说明
+
+### v0.1.1-alpha（2026-08-22）
+
+#### 修复
+
+- 修复 Android 5.1 上接收文件时因 TLS 握手完成监听时序导致请求被错误拒绝的问题。
+- 增加稳定的 TLS 指纹回归测试，覆盖 NanoHTTPD/SSL 握手流程。
+
 ## [v0.1.0-alpha] - 2026-08-22
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "io.github.mouse233.localsendkotlin"
         minSdk = 21
         targetSdk = 33
-        versionCode = 1
-        versionName = "0.1.0-alpha"
+        versionCode = 2
+        versionName = "0.1.1-alpha"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
准备 v0.1.1-alpha 发布：\n\n- 更新 versionCode 到 2、versionName 到 0.1.1-alpha\n- 在 CHANGELOG.md 增加 Android 5.1 TLS 修复说明\n- 保留中英文发布说明\n\n本地已通过 lintDebug、test 和 assembleDebug。