### PR TITLE
ci: sign release APKs in tag workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,23 +28,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run lint, unit tests, and builds
-        run: ./gradlew lintDebug test assembleDebug assembleRelease --no-daemon --stacktrace
-
-      - name: Prepare release APK artifact
-        run: cp app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release.apk
+        run: ./gradlew lintDebug test assembleDebug --no-daemon --stacktrace
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
           name: localsend-kotlin-debug-${{ github.sha }}
           path: app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
-          retention-days: 14
-
-      - name: Upload release APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: localsend-kotlin-release-${{ github.sha }}
-          path: app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,39 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run lint, unit tests, and build
-        run: ./gradlew lintDebug test assembleDebug --no-daemon --stacktrace
+      - name: Validate release signing secrets
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: |
+          test -n "$ANDROID_RELEASE_KEYSTORE_BASE64"
+          test -n "$ANDROID_RELEASE_STORE_PASSWORD"
+          test -n "$ANDROID_RELEASE_KEY_ALIAS"
+          test -n "$ANDROID_RELEASE_KEY_PASSWORD"
 
-      - name: Upload debug APK artifact
+      - name: Restore release keystore
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          keystore_path="$RUNNER_TEMP/localsend-kotlin-release.jks"
+          umask 077
+          printf '%s' "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
+          echo "ANDROID_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
+
+      - name: Run lint, unit tests, and signed release build
+        env:
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: ./gradlew lintDebug test assembleRelease --no-daemon --stacktrace
+
+      - name: Upload signed release APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: localsend-kotlin-debug-${{ github.sha }}
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: localsend-kotlin-release-${{ github.sha }}
+          path: app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
           retention-days: 14
 
@@ -46,10 +71,10 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
-      - name: Download debug APK artifact
+      - name: Download signed release APK artifact
         uses: actions/download-artifact@v4
         with:
-          name: localsend-kotlin-debug-${{ github.sha }}
+          name: localsend-kotlin-release-${{ github.sha }}
           path: release-assets
 
       - name: Extract release notes from CHANGELOG
@@ -75,4 +100,4 @@ jobs:
           tag_name: ${{ github.ref_name }}
           body_path: release-notes.md
           prerelease: ${{ contains(github.ref_name, '-') }}
-          files: release-assets/app-debug.apk
+          files: release-assets/app-release.apk

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 .DS_Store
 /build
 /captures
+*.jks
+*.keystore
+keystore.properties
 .externalNativeBuild
 .cxx
 local.properties

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+/release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,18 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+val releaseStorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+val releaseStorePassword = System.getenv("ANDROID_RELEASE_STORE_PASSWORD")
+val releaseKeyAlias = System.getenv("ANDROID_RELEASE_KEY_ALIAS")
+val releaseKeyPassword = System.getenv("ANDROID_RELEASE_KEY_PASSWORD")
+val releaseSigningValues = listOf(releaseStorePath, releaseStorePassword, releaseKeyAlias, releaseKeyPassword)
+val releaseSigningEnabled = releaseSigningValues.all { !it.isNullOrBlank() }
+
+check(releaseSigningEnabled || releaseSigningValues.all { it.isNullOrBlank() }) {
+    "Release signing requires ANDROID_KEYSTORE_PATH, ANDROID_RELEASE_STORE_PASSWORD, " +
+        "ANDROID_RELEASE_KEY_ALIAS, and ANDROID_RELEASE_KEY_PASSWORD."
+}
+
 android {
     namespace = "io.github.mouse233.localsendkotlin"
     compileSdk = 33
@@ -17,9 +29,23 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    if (releaseSigningEnabled) {
+        signingConfigs {
+            create("release") {
+                storeFile = file(requireNotNull(releaseStorePath))
+                storePassword = requireNotNull(releaseStorePassword)
+                keyAlias = requireNotNull(releaseKeyAlias)
+                keyPassword = requireNotNull(releaseKeyPassword)
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
+            if (releaseSigningEnabled) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
## Summary
- sign tag-release APKs with repository secrets
- publish only the signed app-release.apk asset
- keep regular CI focused on debug builds

## Validation
- ./gradlew lintDebug test assembleDebug assembleRelease --no-daemon --stacktrace
- git diff --check