### PR TITLE
ci: upgrade actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,22 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run lint, unit tests, and builds
         run: ./gradlew lintDebug test assembleDebug --no-daemon --stacktrace
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: localsend-kotlin-debug-${{ github.sha }}
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Validate release signing secrets
         env:
@@ -55,7 +55,7 @@ jobs:
         run: ./gradlew lintDebug test assembleRelease --no-daemon --stacktrace
 
       - name: Upload signed release APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: localsend-kotlin-release-${{ github.sha }}
           path: app/build/outputs/apk/release/app-release.apk
@@ -69,10 +69,10 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download signed release APK artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: localsend-kotlin-release-${{ github.sha }}
           path: release-assets
@@ -94,7 +94,7 @@ jobs:
           test -s release-notes.md
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- upgrade workflow actions to their Node 24 runtime releases
- migrate setup-java to v5

## Validation
- YAML parse for both workflows
- git diff --check