### PR TITLE
chore: ignore local agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.jks
 *.keystore
 keystore.properties
+AGENTS.md
 .externalNativeBuild
 .cxx
 local.properties


### PR DESCRIPTION
Add AGENTS.md to .gitignore so the local-only instructions file is not committed.