### PR TITLE
fix: preserve outgoing transfer history states

### DIFF
--- a/app/src/main/java/io/github/mouse233/localsendkotlin/model/OutgoingTransferState.kt
+++ b/app/src/main/java/io/github/mouse233/localsendkotlin/model/OutgoingTransferState.kt
@@ -1,0 +1,27 @@
+package io.github.mouse233.localsendkotlin.model
+
+/**
+ * Completes only the supplied outgoing sessions, leaving older terminal states untouched.
+ * The caller owns synchronization for the mutable queue map.
+ */
+internal fun <Queue : MutableMap<String, ActiveTransferFile>> finalizeOutgoingSessions(
+    outgoingFiles: MutableMap<String, Queue>,
+    sessionIds: Set<String>,
+    status: ActiveTransferFile.Status
+): List<ActiveTransferFile> {
+    val updated = mutableListOf<ActiveTransferFile>()
+    sessionIds.forEach { sessionId ->
+        outgoingFiles[sessionId]?.values?.toList()?.forEach { file ->
+            if (file.status != ActiveTransferFile.Status.WAITING &&
+                file.status != ActiveTransferFile.Status.TRANSFERRING
+            ) return@forEach
+            val finished = file.copy(
+                receivedBytes = if (status == ActiveTransferFile.Status.COMPLETED) file.totalBytes else file.receivedBytes,
+                status = status
+            )
+            outgoingFiles[sessionId]?.set(file.fileId, finished)
+            updated += finished
+        }
+    }
+    return updated
+}

--- a/app/src/main/java/io/github/mouse233/localsendkotlin/transfer/TransferService.kt
+++ b/app/src/main/java/io/github/mouse233/localsendkotlin/transfer/TransferService.kt
@@ -27,6 +27,7 @@ import io.github.mouse233.localsendkotlin.model.ReceivedFile
 import io.github.mouse233.localsendkotlin.model.RemoteDevice
 import io.github.mouse233.localsendkotlin.model.ActiveTransferFile
 import io.github.mouse233.localsendkotlin.settings.AppSettings
+import io.github.mouse233.localsendkotlin.model.finalizeOutgoingSessions
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -94,6 +95,7 @@ class TransferService : Service(), DiscoveryListener {
     private val incomingFiles = LinkedHashMap<String, LinkedHashMap<String, ActiveTransferFile>>()
     private val incomingSenders = LinkedHashMap<String, String>()
     private val outgoingFiles = LinkedHashMap<String, LinkedHashMap<String, ActiveTransferFile>>()
+    private val outgoingSessionsInProgress = LinkedHashSet<String>()
 
     override fun onCreate() {
         super.onCreate()
@@ -234,7 +236,10 @@ class TransferService : Service(), DiscoveryListener {
                         ActiveTransferFile.Status.WAITING, ActiveTransferFile.Direction.OUTGOING
                     )
                 }
-                synchronized(outgoingFiles) { outgoingFiles[sessionId] = queue }
+                synchronized(outgoingFiles) {
+                    outgoingFiles[sessionId] = queue
+                    outgoingSessionsInProgress += sessionId
+                }
                 notifyListeners { it.onOutgoingSessionPreparing(sessionId, queue.values.toList()) }
             }
 
@@ -255,6 +260,8 @@ class TransferService : Service(), DiscoveryListener {
                 synchronized(outgoingFiles) {
                     outgoingFiles.remove(preparationSessionId)
                     outgoingFiles[sessionId] = queue
+                    outgoingSessionsInProgress.remove(preparationSessionId)
+                    outgoingSessionsInProgress += sessionId
                 }
                 notifyListeners { it.onOutgoingSessionStarted(preparationSessionId, sessionId, queue.values.toList()) }
             }
@@ -460,26 +467,14 @@ class TransferService : Service(), DiscoveryListener {
     }
 
     private fun finishOutgoingQueues(status: ActiveTransferFile.Status) {
+        val sessionIds = synchronized(outgoingFiles) {
+            outgoingSessionsInProgress.toSet().also { outgoingSessionsInProgress.clear() }
+        }
         val updated = synchronized(outgoingFiles) {
-            val states = mutableListOf<ActiveTransferFile>()
-            outgoingFiles.values.forEach { session ->
-                session.values.toList().forEach { file ->
-                    if (file.status != status) {
-                        file.copy(
-                            receivedBytes = if (status == ActiveTransferFile.Status.COMPLETED) file.totalBytes else file.receivedBytes,
-                            status = status
-                        ).also {
-                            session[file.fileId] = it
-                            states += it
-                        }
-                    }
-                }
-            }
-            states
+            finalizeOutgoingSessions(outgoingFiles, sessionIds, status)
         }
         updated.forEach { state -> notifyListeners { it.onFileSendProgress(state) } }
-        val sessions = synchronized(outgoingFiles) { outgoingFiles.keys.toList() }
-        sessions.forEach { sessionId -> notifyListeners { it.onOutgoingSessionCompleted(sessionId) } }
+        sessionIds.forEach { sessionId -> notifyListeners { it.onOutgoingSessionCompleted(sessionId) } }
     }
 
     private fun finishIncomingSession(sessionId: String, status: ActiveTransferFile.Status) {
@@ -514,7 +509,10 @@ class TransferService : Service(), DiscoveryListener {
             incomingFiles.clear()
             incomingSenders.clear()
         }
-        synchronized(outgoingFiles) { outgoingFiles.clear() }
+        synchronized(outgoingFiles) {
+            outgoingFiles.clear()
+            outgoingSessionsInProgress.clear()
+        }
     }
 
     /** Activity callbacks must always run on the main thread because they update Views. */

--- a/app/src/test/java/io/github/mouse233/localsendkotlin/model/TransferSessionTest.kt
+++ b/app/src/test/java/io/github/mouse233/localsendkotlin/model/TransferSessionTest.kt
@@ -1,6 +1,7 @@
 package io.github.mouse233.localsendkotlin.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TransferSessionTest {
@@ -37,5 +38,63 @@ class TransferSessionTest {
 
         assertEquals(true, cancelled.isCancelled())
         assertEquals(false, stillActive.isCancelled())
+    }
+
+    @Test
+    fun finalizingOneOutgoingSessionDoesNotChangeOlderHistory() {
+        val oldSession = linkedMapOf(
+            "old-file" to ActiveTransferFile(
+                "old", "old-file", "old.txt", 1L, 2L,
+                ActiveTransferFile.Status.FAILED,
+                ActiveTransferFile.Direction.OUTGOING
+            )
+        )
+        val currentSession = linkedMapOf(
+            "current-file" to ActiveTransferFile(
+                "current", "current-file", "current.txt", 0L, 4L,
+                ActiveTransferFile.Status.TRANSFERRING,
+                ActiveTransferFile.Direction.OUTGOING
+            )
+        )
+        val queues = linkedMapOf("old" to oldSession, "current" to currentSession)
+
+        val updated = finalizeOutgoingSessions(
+            queues,
+            setOf("current"),
+            ActiveTransferFile.Status.COMPLETED
+        )
+
+        assertEquals(1, updated.size)
+        assertEquals(ActiveTransferFile.Status.FAILED, queues["old"]!!["old-file"]!!.status)
+        assertEquals(ActiveTransferFile.Status.COMPLETED, queues["current"]!!["current-file"]!!.status)
+        assertEquals(4L, queues["current"]!!["current-file"]!!.receivedBytes)
+    }
+
+    @Test
+    fun finalizingSessionKeepsAlreadyTerminalFilesUntouched() {
+        val queues = linkedMapOf(
+            "current" to linkedMapOf(
+                "done" to ActiveTransferFile(
+                    "current", "done", "done.txt", 3L, 3L,
+                    ActiveTransferFile.Status.COMPLETED,
+                    ActiveTransferFile.Direction.OUTGOING
+                ),
+                "cancelled" to ActiveTransferFile(
+                    "current", "cancelled", "cancelled.txt", 1L, 5L,
+                    ActiveTransferFile.Status.CANCELLED,
+                    ActiveTransferFile.Direction.OUTGOING
+                )
+            )
+        )
+
+        val updated = finalizeOutgoingSessions(
+            queues,
+            setOf("current"),
+            ActiveTransferFile.Status.FAILED
+        )
+
+        assertTrue(updated.isEmpty())
+        assertEquals(ActiveTransferFile.Status.COMPLETED, queues["current"]!!["done"]!!.status)
+        assertEquals(ActiveTransferFile.Status.CANCELLED, queues["current"]!!["cancelled"]!!.status)
     }
 }


### PR DESCRIPTION
## Summary
- finalize only outgoing sessions that are currently in progress
- preserve previously completed, failed, and cancelled transfer states
- add regression coverage for historical status preservation

## Verification
- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- `:app:lintDebug`
- installed and launched the debug APK on the connected Xiaomi device